### PR TITLE
Fix WiFi persistence: delay wifi-connect to allow NetworkManager auto…

### DIFF
--- a/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
@@ -276,14 +276,18 @@
     content: |
       [Unit]
       Description=WiFi Connect Captive Portal
-      After=NetworkManager.service
-      Wants=NetworkManager.service
+      After=NetworkManager.service network-online.target
+      Wants=NetworkManager.service network-online.target
 
       [Service]
       Type=simple
+      # Wait 30 seconds for NetworkManager to connect to saved networks
+      ExecStartPre=/bin/sleep 30
+      # Only start if we don't have internet connectivity
+      ExecStartPre=/bin/bash -c '! /usr/bin/nm-online -t 5 -q'
       ExecStart=/usr/local/sbin/wifi-connect --portal-ssid node-setup
       Restart=on-failure
-      RestartSec=30
+      RestartSec=60
 
       [Install]
       WantedBy=multi-user.target


### PR DESCRIPTION
…connect

The wifi-connect captive portal was starting immediately after NetworkManager, preventing saved WiFi connections from auto-connecting on boot. This caused the captive portal to launch on every reboot even though WiFi credentials were saved.

Changes:
- Wait for network-online.target before starting wifi-connect
- Add 30 second delay to give NetworkManager time to connect to saved networks
- Only start wifi-connect if there's no internet connectivity (using nm-online check)
- Increase retry interval from 30s to 60s to reduce unnecessary restarts