### PR TITLE
Add Mender bootstrap artifact for OS version tracking

### DIFF
--- a/plugins/playbooks/board_support/roles/mender/tasks/main.yml
+++ b/plugins/playbooks/board_support/roles/mender/tasks/main.yml
@@ -162,4 +162,4 @@
   loop:
     - mender-client
     - mender-auth
-    - mender-update 
+    - mender-update

--- a/plugins/playbooks/os_setup/roles/radar_data_bootstrap/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_data_bootstrap/tasks/main.yml
@@ -174,3 +174,24 @@
   file:
     path: /tmp/retina-gui
     state: absent
+
+# ======================================================================
+# Mender Bootstrap Artifact
+# ======================================================================
+# Creates bootstrap.mender so Mender dashboard shows OS version on first boot
+# Provides key must match OTA artifact format: rootfs-image.<os_name>.version
+
+- name: Install mender-artifact for bootstrap creation
+  apt:
+    name: mender-artifact
+    state: present
+
+- name: Create bootstrap artifact for initial OS version
+  shell: |
+    mender-artifact write bootstrap-artifact \
+      --device-type "{{ mender_device_type }}-{{ edi_bootstrap_architecture }}" \
+      --artifact-name "{{ os_name }}-v{{ os_version }}" \
+      --provides "rootfs-image.{{ os_name }}.version:v{{ os_version }}" \
+      --output-path /var/lib/mender/bootstrap.mender
+  args:
+    creates: /var/lib/mender/bootstrap.mender

--- a/plugins/postprocessing_commands/genimage/rootfs2image.edi
+++ b/plugins/postprocessing_commands/genimage/rootfs2image.edi
@@ -33,7 +33,7 @@ DISK_IMAGE="{{ pp_image }}"
 PARTITION_IMAGE="{{ pp_partition_image }}"
 WORKDIR="{{ edi_work_directory }}"
 HOSTNAME="{{ hostname }}"
-ARTIFACT_NAME="${BUILD_TIMESTAMP}-{{ edi_configuration_name }}-{{ debian_distribution_release }}-{{ edi_bootstrap_architecture }}"
+ARTIFACT_NAME="{{ os_name }}-v{{ os_version }}"
 
 print_error()
 {


### PR DESCRIPTION
Previously, on first boot from a SD card, the OS version would not show up in the Mender dashboard (but would after subsequent OTA updates), this is problematic for updating nodes.

This PR address this issue by: 
- Creating bootstrap.mender during OS build in radar_data_bootstrap role
- Bootstrap artifact provides rootfs-image.<os_name>.version key
- Mender reads bootstrap.mender on first boot to populate device database

close #5 