### PR TITLE
GUI Wizard: hostname rename, Flask-WTF, retina.local alias, install.lock cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Cloud services (mender-authd, mender-updated, mender-connect) are handled differ
 - **`.img` (fresh flash)** — cloud services are **disabled** by default. `mender.conf` is backed up to `/data/mender-cloud-disabled/` and the three Mender systemd services are masked. The user must consent via the retina-gui install flow to enable them.
 - **`.mender` (OTA artifact)** — cloud services are **re-enabled** via `debugfs` in the `image2mender` post-processing step. This is required because `mender-updated` must start after reboot to run `ArtifactVerifyReboot` and commit the update — without it the update hangs and rolls back.
 
-After install, users can toggle cloud services on/off from `http://retina.local`. The preference persists across reboots and OTA updates. Toggling is blocked while any update is in progress.
+After install, users can toggle cloud services on/off from `http://owl.local`. The preference persists across reboots and OTA updates. Toggling is blocked while any update is in progress.
 
 ### Install Lock
 
@@ -48,7 +48,7 @@ During a retina-node install, retina-gui holds an `install.lock` in `/data/retin
 
 ### Node Configuration
 
-After deploying retina-node, visit `http://retina.local` to configure capture settings, location, ADS-B truth source, and tar1090. See [retina-node](https://github.com/offworldlabs/retina-node) for details.
+After deploying retina-node, visit `http://owl.local` to configure capture settings, location, ADS-B truth source, and tar1090. See [retina-node](https://github.com/offworldlabs/retina-node) for details.
 
 ### Cloudflare Tunnel (Optional)
 
@@ -65,9 +65,9 @@ The token persists across OTA updates.
 
 ### SSH Access
 
-**End users:** Add your SSH key via the web GUI at `http://retina.local` after boot. Once added, connect with:
+**End users:** Add your SSH key via the web GUI at `http://owl.local` after boot. Once added, connect with:
 ```bash
-ssh node@retina.local
+ssh node@owl.local
 # or by IP
 ssh node@<ip-address>
 ```

--- a/owl-os-pi5.yml
+++ b/owl-os-pi5.yml
@@ -60,7 +60,7 @@ postprocessing_commands:
                 location: {{ edi_configuration_name }}_rootfs.ext4
                 type: path
         parameters:
-            hostname: retina
+            hostname: owl
     400_mender:
         path: postprocessing_commands/mender/image2mender.edi
         output:

--- a/plugins/playbooks/board_support/roles/mender/files/state-scripts/ArtifactCommit_Leave_00_retina_state
+++ b/plugins/playbooks/board_support/roles/mender/files/state-scripts/ArtifactCommit_Leave_00_retina_state
@@ -1,4 +1,5 @@
 #!/bin/sh
-# Clear update status file after successful commit.
+# Clear retina-gui state files after successful commit.
 rm -f /data/retina-gui/mender-update.status
+rm -f /data/retina-gui/install.lock
 exit 0

--- a/plugins/playbooks/board_support/roles/mender/files/state-scripts/ArtifactFailure_Enter_00_retina_state
+++ b/plugins/playbooks/board_support/roles/mender/files/state-scripts/ArtifactFailure_Enter_00_retina_state
@@ -1,4 +1,5 @@
 #!/bin/sh
-# Clear update status file on failure or rollback.
+# Clear retina-gui state files on failure or rollback.
 rm -f /data/retina-gui/mender-update.status
+rm -f /data/retina-gui/install.lock
 exit 0

--- a/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
@@ -133,7 +133,7 @@
 
       [Service]
       Type=simple
-      ExecStart=/usr/bin/avahi-publish -a -R retina.local $(ip route get 1 | awk '{print $7;exit}')
+      ExecStart=/bin/bash -c "/usr/bin/avahi-publish -a -R retina.local $(ip route get 1 | awk '{print $7;exit}')"
       Restart=always
       RestartSec=10
 

--- a/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
@@ -94,11 +94,16 @@
       - expect          # Required for SDRplay interactive installer
       - wireless-tools  # Required for iwgetid WiFi connection check
       - python3-flask   # Required for retina-gui web interface
-      - python3-flask-wtf  # Required for retina-gui CSRF protection
       - python3-yaml    # Required for retina-gui config YAML parsing
       - python3-pydantic  # Required for retina-gui form validation
       - python3-requests  # Required for retina-gui Mender API calls
+      - python3-pip     # Required to install Flask-WTF (not in Bookworm apt)
     state: present
+
+- name: Install Flask-WTF via pip (not available as Debian package)
+  pip:
+    name: flask-wtf
+    executable: pip3
 
 # 2a. Install Avahi for mDNS .local hostname resolution
 - name: Install Avahi mDNS daemon

--- a/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
@@ -94,6 +94,7 @@
       - expect          # Required for SDRplay interactive installer
       - wireless-tools  # Required for iwgetid WiFi connection check
       - python3-flask   # Required for retina-gui web interface
+      - python3-flask-wtf  # Required for retina-gui CSRF protection
       - python3-yaml    # Required for retina-gui config YAML parsing
       - python3-pydantic  # Required for retina-gui form validation
       - python3-requests  # Required for retina-gui Mender API calls
@@ -112,6 +113,31 @@
   file:
     src: /lib/systemd/system/avahi-daemon.service
     dest: /etc/systemd/system/multi-user.target.wants/avahi-daemon.service
+    state: link
+
+# 2b. Install retina.local mDNS alias (backwards compatibility for existing nodes)
+- name: Install retina.local avahi alias service
+  copy:
+    dest: /etc/systemd/system/avahi-alias-retina.service
+    content: |
+      [Unit]
+      Description=Publish retina.local as mDNS alias for this device
+      Requires=avahi-daemon.service
+      After=avahi-daemon.service network-online.target
+
+      [Service]
+      Type=simple
+      ExecStart=/usr/bin/avahi-publish -a -R retina.local $(ip route get 1 | awk '{print $7;exit}')
+      Restart=always
+      RestartSec=10
+
+      [Install]
+      WantedBy=multi-user.target
+
+- name: Enable retina.local alias service on boot
+  file:
+    src: /etc/systemd/system/avahi-alias-retina.service
+    dest: /etc/systemd/system/multi-user.target.wants/avahi-alias-retina.service
     state: link
 
 # 3. Install SDRplay API

--- a/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
@@ -104,6 +104,7 @@
   pip:
     name: flask-wtf
     executable: pip3
+    extra_args: --break-system-packages
 
 # 2a. Install Avahi for mDNS .local hostname resolution
 - name: Install Avahi mDNS daemon

--- a/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
@@ -111,6 +111,7 @@
   apt:
     name:
       - avahi-daemon    # mDNS service for .local hostname advertisement
+      - avahi-utils     # Provides avahi-publish for mDNS alias publishing
       - libnss-mdns     # Name service switch module for mDNS resolution
     state: present
     update_cache: yes

--- a/plugins/playbooks/os_setup/versions.yml
+++ b/plugins/playbooks/os_setup/versions.yml
@@ -49,5 +49,5 @@ mender_app_base_url: "https://raw.githubusercontent.com/mendersoftware/app-updat
 
 # retina-gui web interface
 retina_gui_repo_url: "https://github.com/offworldlabs/retina-gui.git"
-retina_gui_version: "v0.1.18"  # GUI Wizard
+retina_gui_version: "v0.1.19"  # GUI Wizard
 

--- a/plugins/playbooks/os_setup/versions.yml
+++ b/plugins/playbooks/os_setup/versions.yml
@@ -49,5 +49,5 @@ mender_app_base_url: "https://raw.githubusercontent.com/mendersoftware/app-updat
 
 # retina-gui web interface
 retina_gui_repo_url: "https://github.com/offworldlabs/retina-gui.git"
-retina_gui_version: "v0.1.14"  # GUI Wizard
+retina_gui_version: "v0.1.18"  # GUI Wizard
 

--- a/plugins/playbooks/os_setup/versions.yml
+++ b/plugins/playbooks/os_setup/versions.yml
@@ -49,5 +49,5 @@ mender_app_base_url: "https://raw.githubusercontent.com/mendersoftware/app-updat
 
 # retina-gui web interface
 retina_gui_repo_url: "https://github.com/offworldlabs/retina-gui.git"
-retina_gui_version: "v0.1.11"  # Safe Cloud Services toggle
+retina_gui_version: "v0.1.12"  # GUI Wizard
 

--- a/plugins/playbooks/os_setup/versions.yml
+++ b/plugins/playbooks/os_setup/versions.yml
@@ -49,5 +49,5 @@ mender_app_base_url: "https://raw.githubusercontent.com/mendersoftware/app-updat
 
 # retina-gui web interface
 retina_gui_repo_url: "https://github.com/offworldlabs/retina-gui.git"
-retina_gui_version: "v0.1.12"  # GUI Wizard
+retina_gui_version: "v0.1.14"  # GUI Wizard
 

--- a/plugins/postprocessing_commands/mender/ArtifactCommit_Leave_00_retina_state
+++ b/plugins/postprocessing_commands/mender/ArtifactCommit_Leave_00_retina_state
@@ -1,4 +1,5 @@
 #!/bin/sh
-# Clear update status file after successful commit.
+# Clear retina-gui state files after successful commit.
 rm -f /data/retina-gui/mender-update.status
+rm -f /data/retina-gui/install.lock
 exit 0

--- a/plugins/postprocessing_commands/mender/ArtifactFailure_Enter_00_retina_state
+++ b/plugins/postprocessing_commands/mender/ArtifactFailure_Enter_00_retina_state
@@ -1,4 +1,5 @@
 #!/bin/sh
-# Clear update status file on failure or rollback.
+# Clear retina-gui state files on failure or rollback.
 rm -f /data/retina-gui/mender-update.status
+rm -f /data/retina-gui/install.lock
 exit 0


### PR DESCRIPTION
## Summary

- **Rename hostname** `retina` → `owl` (`owl.local` is now the primary access point); update README accordingly
- **Bump retina-gui** to `v0.1.19` (GUI Wizard)
- **Flask-WTF**: install via `pip --break-system-packages` since it's absent from Bookworm apt repos; add `python3-pip` dependency
- **retina.local mDNS alias**: publish `retina.local` as a backwards-compatible alias via a new `avahi-alias-retina.service` (uses `avahi-publish`); add `avahi-utils` package
- **install.lock cleanup**: Mender state scripts (`ArtifactCommit_Leave` and `ArtifactFailure_Enter`) now also remove `/data/retina-gui/install.lock` so stale locks don't block re-installs after an OTA update or rollback
