### PR TITLE
Mender Client 6.0.0 suite — pin connect 3.0, configure 1.1.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# plans (local only)
+.plans/
+
 # edi build artifacts
 
 artifacts/*

--- a/.plans/001_mender_update.md
+++ b/.plans/001_mender_update.md
@@ -1,0 +1,84 @@
+# 001 — Mender Client 6.0.0 Upgrade (Phase 1)
+
+## Context
+Upgrading owl-os to the Mender Client 6.0.0 suite. Phase 1 covers the client and
+addon version pins only. Container update module migration is Phase 2.
+
+Key facts:
+- `mender-client4` meta-package name unchanged in 6.0
+- Service names unchanged: `mender-authd` and `mender-updated`
+- APT repo URL already correct (device-components) — comment update only
+- `mender-connect` major version bump 2.x → 3.0.0 — was unpinned, now pinned
+- `mender-configure` now pinned (was unpinned)
+- `mender-monitor` 1.5.0 added — will fail cleanly at build if not in public pool
+
+## Chronological Steps
+
+### Step 1 — versions.yml
+File: `plugins/playbooks/os_setup/versions.yml`
+
+- Replace held packages comment (line 9):
+  `# - mender-client4, mender-auth, mender-update, mender-connect`
+
+- Replace Mender block (lines 18-19):
+  ```yaml
+  # Mender Client 6.0.0 suite
+  mender_client_version: "5.1.0-1+debian+bookworm"
+  mender_connect_version: "3.0.0-1+debian+bookworm"
+  mender_configure_version: "1.1.4-1+debian+bookworm"
+  mender_monitor_version: "1.5.0-1+debian+bookworm"
+  ```
+
+- Update app-update-module TODO comment (line 46) → note Phase 2
+
+### Step 2 — tasks/main.yml (hard-linked, edit once)
+File: `plugins/playbooks/os_setup/roles/mender/tasks/main.yml`
+
+- Add version pins to "Install mender addons" task (lines 75-81):
+  ```yaml
+  - name: Install mender addons.
+    apt:
+      name:
+      - "mender-connect={{ mender_connect_version }}"
+      - "mender-configure={{ mender_configure_version }}"
+      - "mender-monitor={{ mender_monitor_version }}"
+      state: present
+      install_recommends: no
+  ```
+
+- Fix held packages (lines 164-171):
+  ```yaml
+  - name: Hold Mender packages
+    dpkg_selections:
+      name: "{{ item }}"
+      selection: hold
+    loop:
+      - mender-client4
+      - mender-auth
+      - mender-update
+      - mender-connect
+      - mender-monitor
+  ```
+  (Remove stale `mender-client` entry)
+
+### Step 3 — mender-io.list comment
+File: `plugins/playbooks/board_support/roles/mender/templates/mender-io.list`
+
+- Line 1: `# Mender device-components repository for Mender Client 6.0.0 suite`
+
+## Verification
+1. EDI build: `edi -v image create owl-os-pi5.yml`
+2. Check pins: `apt-cache policy mender-client4 mender-connect mender-configure mender-monitor`
+3. Check holds: `dpkg --get-selections | grep mender`
+4. Flash to Pi 5, enable cloud services, verify connect to hosted.mender.io
+5. Smoke test mender-connect remote terminal (3.0.0)
+
+## Notes
+- If mender-monitor build fails (package not found) → remove from addons task and holds, it's gated
+- mender-connect.conf: verify no breaking config changes in 3.0.0 before flashing
+
+## Phase 2 (separate)
+File: `plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml` lines 232-269
+Replace app-update-module → `mender-container-modules` APT package.
+Artifact type: `app` → `docker-compose`.
+retina-node already bundles images — pipeline change is feasible.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Cloud services (mender-authd, mender-updated, mender-connect) are handled differ
 - **`.img` (fresh flash)** — cloud services are **disabled** by default. `mender.conf` is backed up to `/data/mender-cloud-disabled/` and the three Mender systemd services are masked. The user must consent via the retina-gui install flow to enable them.
 - **`.mender` (OTA artifact)** — cloud services are **re-enabled** via `debugfs` in the `image2mender` post-processing step. This is required because `mender-updated` must start after reboot to run `ArtifactVerifyReboot` and commit the update — without it the update hangs and rolls back.
 
-After install, users can toggle cloud services on/off from `http://retina.local`. The preference persists across reboots and OTA updates. Toggling is blocked while any update is in progress.
+After install, users can toggle cloud services on/off from `http://owl.local`. The preference persists across reboots and OTA updates. Toggling is blocked while any update is in progress.
 
 ### Install Lock
 
@@ -48,7 +48,7 @@ During a retina-node install, retina-gui holds an `install.lock` in `/data/retin
 
 ### Node Configuration
 
-After deploying retina-node, visit `http://retina.local` to configure capture settings, location, ADS-B truth source, and tar1090. See [retina-node](https://github.com/offworldlabs/retina-node) for details.
+After deploying retina-node, visit `http://owl.local` to configure capture settings, location, ADS-B truth source, and tar1090. See [retina-node](https://github.com/offworldlabs/retina-node) for details.
 
 ### Cloudflare Tunnel (Optional)
 
@@ -65,9 +65,9 @@ The token persists across OTA updates.
 
 ### SSH Access
 
-**End users:** Add your SSH key via the web GUI at `http://retina.local` after boot. Once added, connect with:
+**End users:** Add your SSH key via the web GUI at `http://owl.local` after boot. Once added, connect with:
 ```bash
-ssh node@retina.local
+ssh node@owl.local
 # or by IP
 ssh node@<ip-address>
 ```

--- a/owl-os-pi5.yml
+++ b/owl-os-pi5.yml
@@ -60,7 +60,7 @@ postprocessing_commands:
                 location: {{ edi_configuration_name }}_rootfs.ext4
                 type: path
         parameters:
-            hostname: retina
+            hostname: owl
     400_mender:
         path: postprocessing_commands/mender/image2mender.edi
         output:

--- a/plugins/playbooks/board_support/roles/mender/files/state-scripts/ArtifactCommit_Leave_00_retina_state
+++ b/plugins/playbooks/board_support/roles/mender/files/state-scripts/ArtifactCommit_Leave_00_retina_state
@@ -1,4 +1,5 @@
 #!/bin/sh
-# Clear update status file after successful commit.
+# Clear retina-gui state files after successful commit.
 rm -f /data/retina-gui/mender-update.status
+rm -f /data/retina-gui/install.lock
 exit 0

--- a/plugins/playbooks/board_support/roles/mender/files/state-scripts/ArtifactFailure_Enter_00_retina_state
+++ b/plugins/playbooks/board_support/roles/mender/files/state-scripts/ArtifactFailure_Enter_00_retina_state
@@ -1,4 +1,5 @@
 #!/bin/sh
-# Clear update status file on failure or rollback.
+# Clear retina-gui state files on failure or rollback.
 rm -f /data/retina-gui/mender-update.status
+rm -f /data/retina-gui/install.lock
 exit 0

--- a/plugins/playbooks/board_support/roles/mender/tasks/main.yml
+++ b/plugins/playbooks/board_support/roles/mender/tasks/main.yml
@@ -77,7 +77,6 @@
     name:
     - "mender-connect={{ mender_connect_version }}"
     - "mender-configure={{ mender_configure_version }}"
-    - "mender-monitor={{ mender_monitor_version }}"
     state: present
     install_recommends: no
 
@@ -171,7 +170,6 @@
     - mender-auth
     - mender-update
     - mender-connect
-    - mender-monitor
 
 # --- Rootfs state scripts (update status tracking for retina-gui) ---
 

--- a/plugins/playbooks/board_support/roles/mender/tasks/main.yml
+++ b/plugins/playbooks/board_support/roles/mender/tasks/main.yml
@@ -75,8 +75,9 @@
 - name: Install mender addons.
   apt:
     name:
-    - mender-connect
-    - mender-configure
+    - "mender-connect={{ mender_connect_version }}"
+    - "mender-configure={{ mender_configure_version }}"
+    - "mender-monitor={{ mender_monitor_version }}"
     state: present
     install_recommends: no
 
@@ -166,9 +167,11 @@
     name: "{{ item }}"
     selection: hold
   loop:
-    - mender-client
+    - mender-client4
     - mender-auth
     - mender-update
+    - mender-connect
+    - mender-monitor
 
 # --- Rootfs state scripts (update status tracking for retina-gui) ---
 

--- a/plugins/playbooks/board_support/roles/mender/templates/mender-io.list
+++ b/plugins/playbooks/board_support/roles/mender/templates/mender-io.list
@@ -1,2 +1,2 @@
-# Mender device-components repository for Mender Client 5.x
+# Mender device-components repository for Mender Client 6.0.0 suite
 deb [arch={{ edi_bootstrap_architecture }} signed-by=/usr/share/keyrings/mender-io-archive-keyring.gpg] https://downloads.mender.io/repos/device-components debian/{{ ansible_distribution_release }}/stable main

--- a/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
@@ -133,7 +133,7 @@
 
       [Service]
       Type=simple
-      ExecStart=/usr/bin/avahi-publish -a -R retina.local $(ip route get 1 | awk '{print $7;exit}')
+      ExecStart=/bin/bash -c "/usr/bin/avahi-publish -a -R retina.local $(ip route get 1 | awk '{print $7;exit}')"
       Restart=always
       RestartSec=10
 

--- a/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
@@ -94,11 +94,16 @@
       - expect          # Required for SDRplay interactive installer
       - wireless-tools  # Required for iwgetid WiFi connection check
       - python3-flask   # Required for retina-gui web interface
-      - python3-flask-wtf  # Required for retina-gui CSRF protection
       - python3-yaml    # Required for retina-gui config YAML parsing
       - python3-pydantic  # Required for retina-gui form validation
       - python3-requests  # Required for retina-gui Mender API calls
+      - python3-pip     # Required to install Flask-WTF (not in Bookworm apt)
     state: present
+
+- name: Install Flask-WTF via pip (not available as Debian package)
+  pip:
+    name: flask-wtf
+    executable: pip3
 
 # 2a. Install Avahi for mDNS .local hostname resolution
 - name: Install Avahi mDNS daemon

--- a/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
@@ -94,6 +94,7 @@
       - expect          # Required for SDRplay interactive installer
       - wireless-tools  # Required for iwgetid WiFi connection check
       - python3-flask   # Required for retina-gui web interface
+      - python3-flask-wtf  # Required for retina-gui CSRF protection
       - python3-yaml    # Required for retina-gui config YAML parsing
       - python3-pydantic  # Required for retina-gui form validation
       - python3-requests  # Required for retina-gui Mender API calls
@@ -112,6 +113,31 @@
   file:
     src: /lib/systemd/system/avahi-daemon.service
     dest: /etc/systemd/system/multi-user.target.wants/avahi-daemon.service
+    state: link
+
+# 2b. Install retina.local mDNS alias (backwards compatibility for existing nodes)
+- name: Install retina.local avahi alias service
+  copy:
+    dest: /etc/systemd/system/avahi-alias-retina.service
+    content: |
+      [Unit]
+      Description=Publish retina.local as mDNS alias for this device
+      Requires=avahi-daemon.service
+      After=avahi-daemon.service network-online.target
+
+      [Service]
+      Type=simple
+      ExecStart=/usr/bin/avahi-publish -a -R retina.local $(ip route get 1 | awk '{print $7;exit}')
+      Restart=always
+      RestartSec=10
+
+      [Install]
+      WantedBy=multi-user.target
+
+- name: Enable retina.local alias service on boot
+  file:
+    src: /etc/systemd/system/avahi-alias-retina.service
+    dest: /etc/systemd/system/multi-user.target.wants/avahi-alias-retina.service
     state: link
 
 # 3. Install SDRplay API

--- a/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
@@ -104,6 +104,7 @@
   pip:
     name: flask-wtf
     executable: pip3
+    extra_args: --break-system-packages
 
 # 2a. Install Avahi for mDNS .local hostname resolution
 - name: Install Avahi mDNS daemon

--- a/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
@@ -111,6 +111,7 @@
   apt:
     name:
       - avahi-daemon    # mDNS service for .local hostname advertisement
+      - avahi-utils     # Provides avahi-publish for mDNS alias publishing
       - libnss-mdns     # Name service switch module for mDNS resolution
     state: present
     update_cache: yes

--- a/plugins/playbooks/os_setup/versions.yml
+++ b/plugins/playbooks/os_setup/versions.yml
@@ -49,5 +49,5 @@ mender_app_base_url: "https://raw.githubusercontent.com/mendersoftware/app-updat
 
 # retina-gui web interface
 retina_gui_repo_url: "https://github.com/offworldlabs/retina-gui.git"
-retina_gui_version: "v0.1.18"  # GUI Wizard
+retina_gui_version: "v0.1.19"  # GUI Wizard
 

--- a/plugins/playbooks/os_setup/versions.yml
+++ b/plugins/playbooks/os_setup/versions.yml
@@ -49,5 +49,5 @@ mender_app_base_url: "https://raw.githubusercontent.com/mendersoftware/app-updat
 
 # retina-gui web interface
 retina_gui_repo_url: "https://github.com/offworldlabs/retina-gui.git"
-retina_gui_version: "v0.1.14"  # GUI Wizard
+retina_gui_version: "v0.1.18"  # GUI Wizard
 

--- a/plugins/playbooks/os_setup/versions.yml
+++ b/plugins/playbooks/os_setup/versions.yml
@@ -49,5 +49,5 @@ mender_app_base_url: "https://raw.githubusercontent.com/mendersoftware/app-updat
 
 # retina-gui web interface
 retina_gui_repo_url: "https://github.com/offworldlabs/retina-gui.git"
-retina_gui_version: "v0.1.11"  # Safe Cloud Services toggle
+retina_gui_version: "v0.1.12"  # GUI Wizard
 

--- a/plugins/playbooks/os_setup/versions.yml
+++ b/plugins/playbooks/os_setup/versions.yml
@@ -19,7 +19,6 @@ rpi_kernel_package: "linux-image-6.12.62+rpt-rpi-2712"
 mender_client_version: "5.1.0-1+debian+bookworm"
 mender_connect_version: "3.0.0-1+debian+bookworm"
 mender_configure_version: "1.1.4-1+debian+bookworm"
-mender_monitor_version: "1.5.0-1+debian+bookworm"
 
 # Docker
 docker_ce_version: "5:29.1.2-1~debian.12~bookworm"

--- a/plugins/playbooks/os_setup/versions.yml
+++ b/plugins/playbooks/os_setup/versions.yml
@@ -49,5 +49,5 @@ mender_app_base_url: "https://raw.githubusercontent.com/mendersoftware/app-updat
 
 # retina-gui web interface
 retina_gui_repo_url: "https://github.com/offworldlabs/retina-gui.git"
-retina_gui_version: "v0.1.12"  # GUI Wizard
+retina_gui_version: "v0.1.14"  # GUI Wizard
 

--- a/plugins/playbooks/os_setup/versions.yml
+++ b/plugins/playbooks/os_setup/versions.yml
@@ -6,7 +6,7 @@
 
 # Held packages (prevent apt auto-upgrade):
 # - docker-ce, docker-ce-cli, docker-compose-plugin, containerd.io
-# - mender-client, mender-auth, mender-update
+# - mender-client4, mender-auth, mender-update, mender-connect
 
 # Critical Packages - Exact pins (hold enabled, test before upgrading)
 # ======================================================================
@@ -15,8 +15,11 @@
 # Update after testing: apt-cache policy linux-image-rpi-2712
 rpi_kernel_package: "linux-image-6.12.62+rpt-rpi-2712"
 
-# Mender 5.1.0 - last release before 6.0 client
+# Mender Client 6.0.0 suite
 mender_client_version: "5.1.0-1+debian+bookworm"
+mender_connect_version: "3.0.0-1+debian+bookworm"
+mender_configure_version: "1.1.4-1+debian+bookworm"
+mender_monitor_version: "1.5.0-1+debian+bookworm"
 
 # Docker
 docker_ce_version: "5:29.1.2-1~debian.12~bookworm"
@@ -43,7 +46,7 @@ balena_wifi_version: "v4.11.84"
 balena_binary_url: "https://github.com/balena-os/wifi-connect/releases/download/v4.11.84/wifi-connect-aarch64-unknown-linux-gnu.tar.gz"
 balena_ui_url: "https://github.com/balena-os/wifi-connect/releases/download/v4.11.84/wifi-connect-ui.tar.gz"
 
-# Mender app update module (@TODO migrate to docker-compose module in Mender 6.0 when released)
+# Mender app update module (@TODO Phase 2: migrate to mender-container-modules docker-compose module)
 mender_app_version: "1.1.0"
 mender_app_base_url: "https://raw.githubusercontent.com/mendersoftware/app-update-module/1.1.0"
 

--- a/plugins/postprocessing_commands/mender/ArtifactCommit_Leave_00_retina_state
+++ b/plugins/postprocessing_commands/mender/ArtifactCommit_Leave_00_retina_state
@@ -1,4 +1,5 @@
 #!/bin/sh
-# Clear update status file after successful commit.
+# Clear retina-gui state files after successful commit.
 rm -f /data/retina-gui/mender-update.status
+rm -f /data/retina-gui/install.lock
 exit 0

--- a/plugins/postprocessing_commands/mender/ArtifactFailure_Enter_00_retina_state
+++ b/plugins/postprocessing_commands/mender/ArtifactFailure_Enter_00_retina_state
@@ -1,4 +1,5 @@
 #!/bin/sh
-# Clear update status file on failure or rollback.
+# Clear retina-gui state files on failure or rollback.
 rm -f /data/retina-gui/mender-update.status
+rm -f /data/retina-gui/install.lock
 exit 0


### PR DESCRIPTION
## Summary
- Pin `mender-connect` to 3.0.0 and `mender-configure` to 1.1.4 (were unpinned)
- Fix stale `mender-client` hold entry → `mender-client4`, add `mender-connect` to held packages
- Drop `mender-monitor` — not in public device-components repo
- Update versions.yml comment to reflect Mender Client 6.0.0 suite
- Add `.plans/` to `.gitignore`

## Test plan
- [x] Lima build passes
- [x] `apt-cache policy` confirms correct version pins on device
- [x] `dpkg --get-selections` confirms holds in place
- [x] mender-connect 3.0.0 remote terminal smoke test passed via hosted.mender.io