### PR TITLE
Migrate to mender-docker-compose, Docker Compose v5, retina-gui v0.1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Connect from a SDRconnect client on another machine using the Pi's IP.
 
 > **Warning:** Conflicts with blah2 - stop containers first:
 > ```bash
-> cd /data/mender-app/retina-node/manifests && docker compose -p retina-node down
+> cd /data/mender-docker-compose/current/manifests && docker compose -p retina-node down
 > ```
 
 ### Mender Tenant Token

--- a/plugins/playbooks/board_support/roles/mender/tasks/main.yml
+++ b/plugins/playbooks/board_support/roles/mender/tasks/main.yml
@@ -171,6 +171,7 @@
     - mender-auth
     - mender-update
     - mender-connect
+    - mender-configure
     - mender-docker-compose
 
 # --- Rootfs state scripts (update status tracking for retina-gui) ---

--- a/plugins/playbooks/board_support/roles/mender/tasks/main.yml
+++ b/plugins/playbooks/board_support/roles/mender/tasks/main.yml
@@ -77,6 +77,7 @@
     name:
     - "mender-connect={{ mender_connect_version }}"
     - "mender-configure={{ mender_configure_version }}"
+    - "mender-docker-compose={{ mender_docker_compose_version }}"
     state: present
     install_recommends: no
 
@@ -170,6 +171,7 @@
     - mender-auth
     - mender-update
     - mender-connect
+    - mender-docker-compose
 
 # --- Rootfs state scripts (update status tracking for retina-gui) ---
 

--- a/plugins/playbooks/os_setup/roles/radar_data_bootstrap/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_data_bootstrap/tasks/main.yml
@@ -89,12 +89,13 @@
       After=docker.service network-online.target
       Wants=network-online.target
       Requires=docker.service
-      ConditionPathExists=/data/mender-app/retina-node/manifests/docker-compose.yaml
+      ConditionPathExists={{ retina_node_manifests_path }}/docker-compose.yaml
 
       [Service]
       Type=oneshot
       RemainAfterExit=yes
-      WorkingDirectory=/data/mender-app/retina-node/manifests
+      WorkingDirectory={{ retina_node_manifests_path }}
+      Environment="RETINA_NODE_PATH={{ retina_node_manifests_path }}"
       ExecStart=/bin/bash -c '/usr/bin/docker compose -p retina-node run --rm config-merger && /usr/bin/docker compose -p retina-node up -d --remove-orphans'
       StartLimitBurst=3
       StartLimitIntervalSec=300

--- a/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
@@ -229,45 +229,6 @@
     insertbefore: "^exit 0"
     line: "udevadm control --reload-rules && udevadm trigger"
 
-# 4. Install Mender app update module for Docker Compose OTA updates
-- name: Install tree and xdelta3 (mender update module)
-  apt:
-    name:
-      - tree
-      - xdelta3
-    state: present
-    update_cache: yes
-
-- name: Create app-modules directory
-  file:
-    path: /usr/share/mender/app-modules/v1
-    state: directory
-    mode: '0755'
-
-- name: Install Mender app update module
-  get_url:
-    url: "{{ mender_app_base_url }}/src/app"
-    dest: /usr/share/mender/modules/v3/app
-    mode: '0755'
-
-- name: Install Docker Compose sub-module
-  get_url:
-    url: "{{ mender_app_base_url }}/src/app-modules/docker-compose"
-    dest: /usr/share/mender/app-modules/v1/docker-compose
-    mode: '0755'
-
-- name: Install mender-app.conf
-  get_url:
-    url: "{{ mender_app_base_url }}/conf/mender-app.conf"
-    dest: /etc/mender/mender-app.conf
-    mode: '0644'
-
-- name: Install mender-app-docker-compose.conf
-  get_url:
-    url: "{{ mender_app_base_url }}/conf/mender-app-docker-compose.conf"
-    dest: /etc/mender/mender-app-docker-compose.conf
-    mode: '0644'
-
 # 5. Install nano for text editing
 - name: Install nano editor
   apt:

--- a/plugins/playbooks/os_setup/versions.yml
+++ b/plugins/playbooks/os_setup/versions.yml
@@ -1,7 +1,6 @@
 ---
-# blah2 OS Package Versions
-# Updated: 2025-12-12
-# OS Version: v0.2.0
+# OWL-OS Package Versions
+# Updated: 2026-4-23
 # Target: Raspberry Pi 5, Debian Bookworm (12.x)
 
 # Held packages (prevent apt auto-upgrade):
@@ -49,5 +48,5 @@ balena_ui_url: "https://github.com/balena-os/wifi-connect/releases/download/v4.1
 
 # retina-gui web interface
 retina_gui_repo_url: "https://github.com/offworldlabs/retina-gui.git"
-retina_gui_version: "v0.1.19"  # GUI Wizard
+retina_gui_version: "v0.1.20"  # mender-docker-compose path
 

--- a/plugins/playbooks/os_setup/versions.yml
+++ b/plugins/playbooks/os_setup/versions.yml
@@ -5,7 +5,7 @@
 
 # Held packages (prevent apt auto-upgrade):
 # - docker-ce, docker-ce-cli, docker-compose-plugin, containerd.io
-# - mender-client4, mender-auth, mender-update, mender-connect, mender-docker-compose
+# - mender-client4, mender-auth, mender-update, mender-connect, mender-configure, mender-docker-compose
 
 # Critical Packages - Exact pins (hold enabled, test before upgrading)
 # ======================================================================

--- a/plugins/playbooks/os_setup/versions.yml
+++ b/plugins/playbooks/os_setup/versions.yml
@@ -6,7 +6,7 @@
 
 # Held packages (prevent apt auto-upgrade):
 # - docker-ce, docker-ce-cli, docker-compose-plugin, containerd.io
-# - mender-client4, mender-auth, mender-update, mender-connect
+# - mender-client4, mender-auth, mender-update, mender-connect, mender-docker-compose
 
 # Critical Packages - Exact pins (hold enabled, test before upgrading)
 # ======================================================================
@@ -19,6 +19,8 @@ rpi_kernel_package: "linux-image-6.12.62+rpt-rpi-2712"
 mender_client_version: "5.1.0-1+debian+bookworm"
 mender_connect_version: "3.0.0-1+debian+bookworm"
 mender_configure_version: "1.1.4-1+debian+bookworm"
+mender_docker_compose_version: "1.0.0-1+debian+bookworm"
+retina_node_manifests_path: "/data/mender-docker-compose/current/manifests"
 
 # Docker
 docker_ce_version: "5:29.1.2-1~debian.12~bookworm"
@@ -26,8 +28,8 @@ docker_cli_version: "5:29.1.2-1~debian.12~bookworm"
 containerd_version: "2.2.0-2~debian.12~bookworm"
 docker_buildx_version: "0.30.1-1~debian.12~bookworm"
 
-# Docker Compose -  exact pin (v5 has breaking changes for old Mender update module)
-docker_compose_version: "2.29.7-1~debian.12~bookworm"
+# Docker Compose - exact pin
+docker_compose_version: "5.1.3-1~debian.12~bookworm"
 
 # Components and Versions
 # ======================================================================
@@ -44,10 +46,6 @@ sdrconnect_url: "https://www.sdrplay.com/software/SDRconnect_linux-arm64_583e89d
 balena_wifi_version: "v4.11.84"
 balena_binary_url: "https://github.com/balena-os/wifi-connect/releases/download/v4.11.84/wifi-connect-aarch64-unknown-linux-gnu.tar.gz"
 balena_ui_url: "https://github.com/balena-os/wifi-connect/releases/download/v4.11.84/wifi-connect-ui.tar.gz"
-
-# Mender app update module (@TODO Phase 2: migrate to mender-container-modules docker-compose module)
-mender_app_version: "1.1.0"
-mender_app_base_url: "https://raw.githubusercontent.com/mendersoftware/app-update-module/1.1.0"
 
 # retina-gui web interface
 retina_gui_repo_url: "https://github.com/offworldlabs/retina-gui.git"

--- a/plugins/playbooks/os_setup/versions.yml
+++ b/plugins/playbooks/os_setup/versions.yml
@@ -48,5 +48,5 @@ balena_ui_url: "https://github.com/balena-os/wifi-connect/releases/download/v4.1
 
 # retina-gui web interface
 retina_gui_repo_url: "https://github.com/offworldlabs/retina-gui.git"
-retina_gui_version: "v0.1.20"  # mender-docker-compose path
+retina_gui_version: "v0.1.21"  # mender-docker-compose path
 


### PR DESCRIPTION
## Summary
- Migrate from `app-update-module` to `mender-docker-compose` APT package (Mender 6.0)
- Update Docker Compose to v5.1.3 (previously held back by app-update-module)
- Update `retina-node.service` paths to `/data/mender-docker-compose/current/manifests/`
- Hold `mender-configure` and `mender-docker-compose` packages
- Bump retina-gui to v0.1.21 (fixes version reporting for new module)

## Breaking change
Must deploy `retina-node v0.4.0` after this OS update. See migration steps in release notes.
