### PR TITLE
GUI v0.2.1, mender-connect 3.0.0-2, wifi-connect download retries

### DIFF
--- a/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
@@ -364,6 +364,10 @@
     src: "{{ balena_binary_url }}"
     dest: /tmp/
     remote_src: yes
+  retries: 3
+  delay: 10
+  register: result
+  until: result is succeeded
 
 - name: Install wifi-connect binary
   copy:
@@ -382,6 +386,10 @@
     src: "{{ balena_ui_url }}"
     dest: /tmp/wifi-ui-temp/
     remote_src: yes
+  retries: 3
+  delay: 10
+  register: result
+  until: result is succeeded
 
 - name: Create wifi-connect directory
   file:

--- a/plugins/playbooks/os_setup/versions.yml
+++ b/plugins/playbooks/os_setup/versions.yml
@@ -48,5 +48,5 @@ balena_ui_url: "https://github.com/balena-os/wifi-connect/releases/download/v4.1
 
 # retina-gui web interface
 retina_gui_repo_url: "https://github.com/offworldlabs/retina-gui.git"
-retina_gui_version: "v0.1.21"  # mender-docker-compose path
+retina_gui_version: "v0.2.1"  # mender-docker-compose path
 

--- a/plugins/playbooks/os_setup/versions.yml
+++ b/plugins/playbooks/os_setup/versions.yml
@@ -16,7 +16,7 @@ rpi_kernel_package: "linux-image-6.12.62+rpt-rpi-2712"
 
 # Mender Client 6.0.0 suite
 mender_client_version: "5.1.0-1+debian+bookworm"
-mender_connect_version: "3.0.0-1+debian+bookworm"
+mender_connect_version: "3.0.0-2+debian+bookworm"
 mender_configure_version: "1.1.4-1+debian+bookworm"
 mender_docker_compose_version: "1.0.0-1+debian+bookworm"
 retina_node_manifests_path: "/data/mender-docker-compose/current/manifests"


### PR DESCRIPTION
## Summary

Reconciles `main` with what was actually shipped in OS image `os-v0.8.06` (built 2026-05-14 from this branch's tip). These three commits were tagged and released but never merged back to `main`.

- Bump `retina_gui_version` to `v0.2.1` (from `v0.1.21`)
- Bump `mender_connect_version` to `3.0.0-2` (from `3.0.0-1`)
- Add `retries: 3`/`delay: 10`/`until: result is succeeded` to the two wifi-connect (balena binary + UI) `ansible.builtin.unarchive` tasks to harden against transient GitHub download failures

## Test plan

- [x] Already validated — `os-v0.8.06` was built from this exact commit (`5fba081`) and shipped successfully
- [ ] Confirm no regressions vs main on a fresh build after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)