### PR TITLE
Make Mender node_id generation always authoritative on RPi

### DIFF
--- a/configuration/mender/identity/mender-device-identity
+++ b/configuration/mender/identity/mender-device-identity
@@ -5,15 +5,37 @@
 # Generates a human-readable node_id from the Raspberry Pi serial number.
 # Format: ret + last 8 hex chars of serial (e.g., ret7dd2cb0d)
 #
-# The node_id is generated once and persisted at /data/mender/node_id.
-# Falls back to MAC address for non-RPi hardware.
+# On RPi hardware the serial is always authoritative — the cache is refreshed
+# if it differs (guards against stale ids baked into golden images).
+# Falls back to cached node_id or MAC address for non-RPi hardware.
 
 set -ue
 
 NODE_ID_FILE=/data/mender/node_id
 MAC_FILE=/sys/class/net/{{ 'end0' if mender_device_type in ['pi4-v3', 'pi5-v3'] else 'eth0' }}/address
 
-# Return existing node_id if already generated
+# On RPi hardware derive node_id from serial — always, not just on first boot.
+if grep -q "Raspberry Pi\|BCM" /proc/cpuinfo 2>/dev/null; then
+    SERIAL=$(grep "^Serial" /proc/cpuinfo | cut -d: -f2 | tr -d ' ')
+    if [ -n "${SERIAL}" ] && [ "${SERIAL}" != "0000000000000000" ]; then
+        NODE_ID="ret${SERIAL: -8}"
+
+        # Refresh cache if absent or stale
+        CACHED=""
+        [ -f "${NODE_ID_FILE}" ] && CACHED=$(cat "${NODE_ID_FILE}" | tr -d '[:space:]')
+        if [ "${CACHED}" != "${NODE_ID}" ]; then
+            mkdir -p "$(dirname ${NODE_ID_FILE})"
+            TEMP_FILE="${NODE_ID_FILE}.tmp.$$"
+            echo "${NODE_ID}" > "${TEMP_FILE}"
+            mv "${TEMP_FILE}" "${NODE_ID_FILE}"
+        fi
+
+        echo "node_id=${NODE_ID}"
+        exit 0
+    fi
+fi
+
+# Non-RPi hardware: use cached node_id if present
 if [ -f "${NODE_ID_FILE}" ]; then
     NODE_ID=$(cat "${NODE_ID_FILE}" | tr -d '[:space:]')
     if [ -n "${NODE_ID}" ]; then
@@ -22,26 +44,7 @@ if [ -f "${NODE_ID_FILE}" ]; then
     fi
 fi
 
-# Generate node_id from RPi serial (first boot)
-if grep -q "Raspberry Pi\|BCM" /proc/cpuinfo 2>/dev/null; then
-    SERIAL=$(grep "^Serial" /proc/cpuinfo | cut -d: -f2 | tr -d ' ')
-    if [ -n "${SERIAL}" ] && [ "${SERIAL}" != "0000000000000000" ]; then
-        # Take last 8 hex characters
-        SERIAL_SUFFIX="${SERIAL: -8}"
-        NODE_ID="ret${SERIAL_SUFFIX}"
-
-        # Persist for future calls (atomic write)
-        mkdir -p "$(dirname ${NODE_ID_FILE})"
-        TEMP_FILE="${NODE_ID_FILE}.tmp.$$"
-        echo "${NODE_ID}" > "${TEMP_FILE}"
-        mv "${TEMP_FILE}" "${NODE_ID_FILE}"
-
-        echo "node_id=${NODE_ID}"
-        exit 0
-    fi
-fi
-
-# Fallback to MAC address for non-RPi hardware
+# Fallback to MAC address
 if [ ! -f "${MAC_FILE}" ]; then
     >&2 echo "Error: ${MAC_FILE} not found and could not generate node_id!"
     exit 1

--- a/plugins/postprocessing_commands/genimage/rootfs2image.edi
+++ b/plugins/postprocessing_commands/genimage/rootfs2image.edi
@@ -96,6 +96,8 @@ fi
 # Remove /etc/machine-id and /var/lib/dbus/machine-id (it should be unique for each system).
 rm rootfs/etc/machine-id
 rm rootfs/var/lib/dbus/machine-id
+# Remove cached Mender node_id so each device generates its own from its serial on first boot.
+rm -f rootfs/data/mender/node_id
 # Add fstab.
 cp "${PLUGIN_DIRECTORY}/fstab" rootfs/etc/
 

--- a/plugins/postprocessing_commands/image/rootfs2image
+++ b/plugins/postprocessing_commands/image/rootfs2image
@@ -220,6 +220,9 @@ mount "${DATA_LD}" "${DATA_MNT}"
 # Copy all files from the LXD rootfs to the loop device mount point directory
 rsync -a -H --exclude 'usr/share/doc/*/changelog.Debian.gz' --exclude 'usr/share/doc/*/changelog.gz' "${ROOTFS_DIR}/" "${ROOT_MNT}/"
 
+# Remove cached Mender node_id so each device generates its own from its serial on first boot.
+rm -f "${DATA_MNT}/mender/node_id"
+
 do_unmount
 
 zerofree "${ROOT_LD}"


### PR DESCRIPTION
## Summary
This change modifies the Mender device identity generation to always derive the node_id from the Raspberry Pi serial number on RPi hardware, rather than only on first boot. This ensures that stale node_id values baked into golden images are automatically refreshed, while maintaining backward compatibility with cached values on non-RPi hardware.

## Key Changes
- **RPi serial as authoritative source**: On Raspberry Pi hardware, the node_id is now always derived from `/proc/cpuinfo` serial, not just on first boot
- **Cache refresh logic**: The cached node_id is only updated if it differs from the current serial-derived value, preventing unnecessary writes
- **Improved fallback chain**: Non-RPi hardware now falls back to cached node_id first, then MAC address as a last resort
- **Golden image cleanup**: Both `rootfs2image` and `rootfs2image.edi` now remove cached node_id files during image generation to ensure each device generates its own unique ID on first boot
- **Atomic writes preserved**: The existing atomic write pattern (using temporary files and `mv`) is maintained for cache updates

## Implementation Details
- The RPi detection logic remains unchanged (checking for "Raspberry Pi" or "BCM" in `/proc/cpuinfo`)
- The node_id format stays consistent: `ret` prefix + last 8 hex characters of serial
- Cache refresh only occurs when the computed node_id differs from the cached value, optimizing for the common case where they match
- The cleanup in image generation scripts ensures golden images don't carry stale node_id values that could cause device identity collisions

https://claude.ai/code/session_014KRrakaPXvCUSgXQcjvKhs