### PR TITLE
20260601 - Deploy RSPduo watchdog script 

### DIFF
--- a/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
@@ -14,6 +14,7 @@
 #   7. Cloudflared - Secure tunneling for remote access
 #   8. SDRconnect - Standalone SDR analysis tool
 #   9. WiFi Connect captive portal (Balena) - Easy WiFi setup
+#  10. RSPduo watchdog - Cron-based health check for automatic recovery
 #
 # Target: Raspberry Pi 5 fleet running Debian Bookworm (12.x)
 #
@@ -455,4 +456,45 @@
     - docker-compose-plugin
     - docker-buildx-plugin
     - containerd.io
+
+# 9. RSPduo watchdog: cron-based health check that auto-restarts the stack on detection failure
+- name: Create blah2 script directory
+  file:
+    path: /opt/blah2/script
+    state: directory
+    mode: '0755'
+
+- name: Install RSPduo watchdog script
+  copy:
+    dest: /opt/blah2/script/blah2_rspduo_restart.bash
+    mode: '0755'
+    content: |
+      #!/bin/bash
+
+      # Run script with a crontab to automatically restart on error.
+      # Checks the API to see if data is still being pushed through.
+
+      COMPOSE_FILE=/data/mender-docker-compose/current/manifests/docker-compose.yaml
+      PROJECT=retina-node
+
+      FIRST_CHAR=$(curl -s 127.0.0.1:3000/api/map | head -c1)
+      TIMESTAMP=$(curl -s 127.0.0.1:3000/api/map | head -c23 | tail -c10)
+      CURR_TIMESTAMP=$(date +%s)
+      DIFF_TIMESTAMP=$(($CURR_TIMESTAMP-$TIMESTAMP))
+
+      if [[ "$FIRST_CHAR" != "{" ]] || [[ $DIFF_TIMESTAMP -gt 60 ]]; then
+        docker compose -p $PROJECT -f $COMPOSE_FILE down
+        kill -9 $(pgrep -f "sdrplay_apiService") 2>/dev/null || true
+        systemctl restart sdrplay.service
+        docker compose -p $PROJECT -f $COMPOSE_FILE up -d
+        echo "Successfully restarted blah2"
+      fi
+
+- name: Install RSPduo watchdog cron job
+  copy:
+    dest: /etc/cron.d/blah2-rspduo-watchdog
+    mode: '0644'
+    content: |
+      # RSPduo health check: restart retina-node stack if blah2 API data is stale (>60s)
+      */5 * * * *  root  /opt/blah2/script/blah2_rspduo_restart.bash
 


### PR DESCRIPTION
## Summary

- Deploys `blah2_rspduo_restart.bash` to `/opt/blah2/script/` on each node via the `radar_packages` Ansible role
- Installs a cron job at `/etc/cron.d/blah2-rspduo-watchdog` that runs the script every 5 minutes as root

## Background

The watchdog script existed in the blah2-arm repo but was never deployed to any node. When the RSPduo hardware fails to be detected, blah2 calls `exit(1)` and Docker's `restart: always` puts it into a crash loop — with no automatic recovery mechanism, the only fix was manual intervention.

A companion change in blah2-arm updates the script's `docker compose` commands to target the correct `retina-node` stack (previously pointed at the old standalone `/opt/blah2/docker-compose.yml`).

## How it works

Every 5 minutes, the cron job hits `127.0.0.1:3000/api/map` and checks two things:
1. The response is valid JSON (API is up)
2. The embedded timestamp is less than 60 seconds stale (data is flowing)

If either check fails, it tears down the `retina-node` stack, restarts the `sdrplay` systemd service to break the crash loop, then brings the stack back up.