### PR TITLE
20260618 - Mirror blah2-arm watchdog guards against racing GUI config.

### DIFF
--- a/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
@@ -485,10 +485,30 @@
       COMPOSE_FILE=/data/mender-docker-compose/current/manifests/docker-compose.yaml
       PROJECT=retina-node
       MODE_FILE=/data/retina-gui/mode.txt
+      GRACE_PERIOD_SECONDS=60
 
       # Don't interfere when spectrum mode is active - blah2 is intentionally stopped
       if [ -f "$MODE_FILE" ] && [ "$(cat $MODE_FILE)" = "spectrum" ]; then
         exit 0
+      fi
+
+      # Don't race a restart already in flight - a GUI config Apply (or another
+      # instance of this script) may already be running `docker compose down`/`up`
+      # against the same project; piling another one on top can corrupt both.
+      if pgrep -f "docker compose -p $PROJECT" > /dev/null; then
+        exit 0
+      fi
+
+      # Give blah2 a grace period after a (re)start before judging it stale - it
+      # needs time to re-acquire the RSPduo and start producing fresh map data,
+      # whether the restart just came from this script or a GUI config Apply.
+      CONTAINER_STARTED=$(docker inspect -f '{% raw %}{{.State.StartedAt}}{% endraw %}' blah2 2>/dev/null)
+      if [ -n "$CONTAINER_STARTED" ]; then
+        STARTED_EPOCH=$(date -d "$CONTAINER_STARTED" +%s 2>/dev/null)
+        NOW_EPOCH=$(date +%s)
+        if [ -n "$STARTED_EPOCH" ] && [ $((NOW_EPOCH - STARTED_EPOCH)) -lt $GRACE_PERIOD_SECONDS ]; then
+          exit 0
+        fi
       fi
 
       FIRST_CHAR=$(curl -s 127.0.0.1:3000/api/map | head -c1)


### PR DESCRIPTION
The cron watchdog and a GUI config Apply can independently restart the
same docker compose project with no mutual exclusion between them. Skip
a watchdog cycle if a `docker compose -p retina-node` operation is
already running, and give blah2 a 60s grace period after a restart
before judging /api/map stale, so the two restart paths can't pile on
top of each other or fire while the stack is still warming up.