### PR TITLE
20260618 host name retina

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ During a retina-node install, retina-gui holds an `install.lock` in `/data/retin
 
 ### Node Configuration
 
-After deploying retina-node, visit `http://owl.local` to configure capture settings, location, ADS-B truth source, and tar1090. See [retina-node](https://github.com/offworldlabs/retina-node) for details.
+After deploying retina-node, visit `http://retina.local` to configure capture settings, location, ADS-B truth source, and tar1090. See [retina-node](https://github.com/offworldlabs/retina-node) for details. (The node renames itself from `owl.local` to `retina.local` once retina-node is deployed; `owl.local` still works and redirects to `retina.local`.)
 
 ### Cloudflare Tunnel (Optional)
 

--- a/plugins/playbooks/os_setup/roles/radar_data_bootstrap/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_data_bootstrap/tasks/main.yml
@@ -171,6 +171,35 @@
     dest: /etc/systemd/system/multi-user.target.wants/retina-hostname-swap.path
     state: link
 
+# Once the device is renamed to retina, keep owl.local resolving too, so
+# anyone who bookmarked/scripted against the old name during onboarding
+# doesn't lose access. Permanent, mirrors the one-way rename above.
+- name: Install owl.local backwards-compat alias service
+  copy:
+    dest: /etc/systemd/system/avahi-alias-owl.service
+    mode: '0644'
+    content: |
+      [Unit]
+      Description=Publish owl.local as a backwards-compat mDNS alias once renamed to retina
+      ConditionPathExists={{ retina_node_manifests_path }}/docker-compose.yaml
+      Requires=avahi-daemon.service
+      After=avahi-daemon.service network-online.target retina-hostname-swap.service
+
+      [Service]
+      Type=simple
+      ExecStart=/bin/bash -c "/usr/bin/avahi-publish -a -R owl.local $(ip route get 1 | awk '{print $7;exit}')"
+      Restart=always
+      RestartSec=10
+
+      [Install]
+      WantedBy=multi-user.target
+
+- name: Enable owl.local backwards-compat alias service on boot
+  file:
+    src: /etc/systemd/system/avahi-alias-owl.service
+    dest: /etc/systemd/system/multi-user.target.wants/avahi-alias-owl.service
+    state: link
+
 # ======================================================================
 # retina-gui Web Interface
 # ======================================================================

--- a/plugins/playbooks/os_setup/roles/radar_data_bootstrap/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_data_bootstrap/tasks/main.yml
@@ -110,6 +110,68 @@
     state: link
 
 # ======================================================================
+# mDNS hostname lifecycle swap: owl.local -> retina.local
+# ======================================================================
+# Before retina-node is deployed, the node is just an "owl-os radar kit"
+# going through onboarding and presents as owl.local. Once Mender has
+# deployed the retina-node artifact (signaled by the same manifests file
+# retina-node.service above conditions on), it's a real radar node, so we
+# rename the host so avahi naturally advertises retina.local instead.
+# This is a one-way transition - it does not revert if retina-node is
+# later removed.
+
+- name: Install retina-node hostname swap script
+  copy:
+    dest: /usr/local/sbin/retina-hostname-swap.bash
+    mode: '0755'
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      set -euo pipefail
+
+      if [ "$(hostname)" = "retina" ]; then
+        exit 0
+      fi
+
+      hostnamectl set-hostname retina
+      sed -i 's/^127.0.1.1.*/127.0.1.1   retina/' /etc/hosts
+      systemctl restart avahi-daemon
+
+- name: Install retina-node hostname swap path unit
+  copy:
+    dest: /etc/systemd/system/retina-hostname-swap.path
+    mode: '0644'
+    content: |
+      [Unit]
+      Description=Watch for retina-node installation to trigger mDNS hostname swap
+
+      [Path]
+      PathExists={{ retina_node_manifests_path }}/docker-compose.yaml
+
+      [Install]
+      WantedBy=multi-user.target
+
+- name: Install retina-node hostname swap service
+  copy:
+    dest: /etc/systemd/system/retina-hostname-swap.service
+    mode: '0644'
+    content: |
+      [Unit]
+      Description=Swap mDNS hostname from owl.local to retina.local once retina-node is installed
+      ConditionPathExists={{ retina_node_manifests_path }}/docker-compose.yaml
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/local/sbin/retina-hostname-swap.bash
+
+- name: Enable retina-node hostname swap path unit
+  file:
+    src: /etc/systemd/system/retina-hostname-swap.path
+    dest: /etc/systemd/system/multi-user.target.wants/retina-hostname-swap.path
+    state: link
+
+# ======================================================================
 # retina-gui Web Interface
 # ======================================================================
 

--- a/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
@@ -8,7 +8,8 @@
 #   1. Docker CE 27.x & Docker Compose v2 - Container runtime for blah2 services
 #   2. System dependencies (graphviz, libusb, libudev, expect, wireless-tools)
 #   3. Avahi mDNS daemon - .local hostname resolution (owl.local until retina-node
-#      is installed, see radar_data_bootstrap for the retina.local hostname swap)
+#      is installed, see radar_data_bootstrap for the retina.local hostname swap
+#      and the owl.local backwards-compat alias kept alongside it)
 #   4. SDRplay API v3.15.2 - Hardware driver for RSPDuo SDR
 #   5. Mender Docker Update Module and requirements
 #   6. Chrony - NTP clock disciplining for accurate timing
@@ -121,6 +122,7 @@
   apt:
     name:
       - avahi-daemon    # mDNS service for .local hostname advertisement
+      - avahi-utils     # Provides avahi-publish for the owl.local backwards-compat alias
       - libnss-mdns     # Name service switch module for mDNS resolution
     state: present
     update_cache: yes

--- a/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
@@ -7,7 +7,8 @@
 # This playbook installs the essential system components needed to run blah2 on Raspberry Pi 5:
 #   1. Docker CE 27.x & Docker Compose v2 - Container runtime for blah2 services
 #   2. System dependencies (graphviz, libusb, libudev, expect, wireless-tools)
-#   3. Avahi mDNS daemon - .local hostname resolution
+#   3. Avahi mDNS daemon - .local hostname resolution (owl.local until retina-node
+#      is installed, see radar_data_bootstrap for the retina.local hostname swap)
 #   4. SDRplay API v3.15.2 - Hardware driver for RSPDuo SDR
 #   5. Mender Docker Update Module and requirements
 #   6. Chrony - NTP clock disciplining for accurate timing
@@ -120,7 +121,6 @@
   apt:
     name:
       - avahi-daemon    # mDNS service for .local hostname advertisement
-      - avahi-utils     # Provides avahi-publish for mDNS alias publishing
       - libnss-mdns     # Name service switch module for mDNS resolution
     state: present
     update_cache: yes
@@ -129,31 +129,6 @@
   file:
     src: /lib/systemd/system/avahi-daemon.service
     dest: /etc/systemd/system/multi-user.target.wants/avahi-daemon.service
-    state: link
-
-# 2b. Install retina.local mDNS alias (backwards compatibility for existing nodes)
-- name: Install retina.local avahi alias service
-  copy:
-    dest: /etc/systemd/system/avahi-alias-retina.service
-    content: |
-      [Unit]
-      Description=Publish retina.local as mDNS alias for this device
-      Requires=avahi-daemon.service
-      After=avahi-daemon.service network-online.target
-
-      [Service]
-      Type=simple
-      ExecStart=/bin/bash -c "/usr/bin/avahi-publish -a -R retina.local $(ip route get 1 | awk '{print $7;exit}')"
-      Restart=always
-      RestartSec=10
-
-      [Install]
-      WantedBy=multi-user.target
-
-- name: Enable retina.local alias service on boot
-  file:
-    src: /etc/systemd/system/avahi-alias-retina.service
-    dest: /etc/systemd/system/multi-user.target.wants/avahi-alias-retina.service
     state: link
 
 # 3. Install SDRplay API


### PR DESCRIPTION
A systemd path unit watches for {{ retina_node_manifests_path }}/docker-compose.yaml (the file Mender writes when it deploys the mender-docker-compose retina-node artifact — the same condition retina-node.service already uses). When it appears, a oneshot service runs hostnamectl set-hostname retina, which makes avahi-daemon naturally start publishing retina.local instead of owl.local. This is one-way: if retina-node is later removed, the hostname won't revert to owl. There is simply no need for this.
To avoid breaking anyone who bookmarked or scripted against owl.local during onboarding, a second service — gated on the same manifest file — publishes owl.local as a permanent mDNS alias via avahi-publish once the rename has happened. It mirrors the old avahi-alias-retina.service pattern, just in reverse: retina is now the real hostname, owl.local is the alias, and it only starts once the device has actually become a radar node, instead of running unconditionally from first boot.
On the GUI side, retina-gui adds a before_request redirect: any request arriving with Host: owl.local (and the manifest already present) gets a 308 redirect to the same path on retina.local, so the address bar always ends up showing the canonical name rather than just leaving DNS to resolve silently to the same content.
radar_packages/tasks/main.yml: delete the static avahi-alias-retina.service block — superseded by the real hostname swap. Keep avahi-utils, since avahi-publish is now needed for the reversed owl.local backwards-compat alias added in radar_data_bootstrap.
radar_data_bootstrap/tasks/main.yml: add the swap script, path unit, and oneshot service, alongside the existing retina-node.service (same file already defines retina_node_manifests_path-gated logic). Also add avahi-alias-owl.service, gated on the same manifest path and ordered after the swap service, to keep owl.local resolving permanently post-rename.