### PR TITLE
20260629 sdrconnect mode

### DIFF
--- a/plugins/playbooks/os_setup/roles/radar_data_bootstrap/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_data_bootstrap/tasks/main.yml
@@ -148,6 +148,15 @@
     dest: /etc/systemd/system/multi-user.target.wants/retina-gui.service
     state: link
 
+# Install sdrconnect systemd unit (started/stopped on demand by retina-gui's
+# mode switcher — never enabled for boot, since it would conflict with blah2).
+- name: Copy sdrconnect systemd service
+  copy:
+    src: /tmp/retina-gui/systemd/sdrconnect.service
+    dest: /etc/systemd/system/sdrconnect.service
+    mode: '0644'
+    remote_src: yes
+
 # 10. Configure SSH to read authorized_keys from /data/
 - name: Configure sshd AuthorizedKeysFile for persistent keys
   lineinfile:

--- a/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
+++ b/plugins/playbooks/os_setup/roles/radar_packages/tasks/main.yml
@@ -536,8 +536,8 @@
       MODE_FILE=/data/retina-gui/mode.txt
       GRACE_PERIOD_SECONDS=60
 
-      # Don't interfere when spectrum mode is active - blah2 is intentionally stopped
-      if [ -f "$MODE_FILE" ] && [ "$(cat $MODE_FILE)" = "spectrum" ]; then
+      # Don't interfere when spectrum or sdrconnect mode is active - blah2 is intentionally stopped
+      if [ -f "$MODE_FILE" ] && { [ "$(cat $MODE_FILE)" = "spectrum" ] || [ "$(cat $MODE_FILE)" = "sdrconnect" ]; }; then
         exit 0
       fi
 


### PR DESCRIPTION
## Deploy sdrconnect.service and fix watchdog interference

### Summary
Companion to the retina-gui PR adding SDRconnect as a third node mode. Two
unrelated fixes bundled because they were both required to get SDRconnect
working end-to-end on a real device:

1. Deploy the new `sdrconnect.service` systemd unit.
2. Stop the RSPduo watchdog cron job from undoing SDRconnect mode.

### Changes
- **`radar_data_bootstrap/tasks/main.yml`** — copies
  `systemd/sdrconnect.service` from the already-cloned retina-gui checkout to
  `/etc/systemd/system/`, mirroring the existing `retina-gui.service`
  deployment in this same role. Deliberately **not** enabled for boot (no
  `multi-user.target.wants` symlink) — it must stay dormant until retina-gui's
  mode switcher starts it, since running it unconditionally would conflict
  with blah2 for the SDR device.
- **`radar_packages/tasks/main.yml`** — the inline RSPduo watchdog script
  (rendered to `/opt/blah2/script/blah2_rspduo_restart.bash`) only checked for
  `mode.txt == spectrum` before deciding blah2 being down was intentional.
  With `sdrconnect` now also stopping blah2, the watchdog was bringing blah2
  back up every 5 minutes while a user was actively using SDRconnect — caught
  this happening live on a test node. Extends the guard to skip the restart
  for `sdrconnect` mode too.